### PR TITLE
Fix for <Issue while comparing table using daisy diff #8>

### DIFF
--- a/src/main/java/org/outerj/daisy/diff/html/TextNodeComparator.java
+++ b/src/main/java/org/outerj/daisy/diff/html/TextNodeComparator.java
@@ -343,7 +343,7 @@ boolean useAfter = false;
                     .getParent()
                     .getMatchRatio(nextResult.getLastCommonParent());
 
-                    if (distancePrev <= distanceNext) {
+                    if (distancePrev < distanceNext) {
                     	// insert after the previous node
                         prevResult.setLastCommonParentDepth(prevResult
                                 .getLastCommonParentDepth() + 1);

--- a/src/test/resources/testdata/Tables/09 Multiple text changes/expected.html
+++ b/src/test/resources/testdata/Tables/09 Multiple text changes/expected.html
@@ -15,7 +15,7 @@
 <td>Red</td><td>Yellow</td>
 </tr>
 <tr>
-<td>Blue<span class="diff-html-removed" id="removed-diff-7" previous="removed-diff-6" changeId="removed-diff-7" next="added-diff-8">Green</span></td><td><span class="diff-html-added" id="added-diff-8" previous="removed-diff-7" changeId="added-diff-8" next="added-diff-9">Brown</span></td>
+<td>Blue</td><td><span class="diff-html-removed" id="removed-diff-7" previous="removed-diff-6" changeId="removed-diff-7" next="added-diff-8">Green</span><span class="diff-html-added" id="added-diff-8" previous="removed-diff-7" changeId="added-diff-8" next="added-diff-9">Brown</span></td>
 </tr>
 <tr>
 <td>Black</td><td>White <span class="diff-html-added" id="added-diff-9" previous="added-diff-8" changeId="added-diff-9" next="last-diff">23</span></td>


### PR DESCRIPTION
Fix for <Issue while comparing table using daisy diff #8>
Updated the Test Case where the changed <td> value was set to the
previous <td>. But it should be highlighted in the same <td>.
https://github.com/DaisyDiff/DaisyDiff/pull/12.patch