### PR TITLE
Fix for <Node.getLastCommonParent Algorithm #5>

### DIFF
--- a/src/main/java/org/outerj/daisy/diff/html/dom/Node.java
+++ b/src/main/java/org/outerj/daisy/diff/html/dom/Node.java
@@ -120,7 +120,8 @@ public abstract class Node {
         int i = 1;
         boolean isSame = true;
         while (isSame && i < myParents.size() && i < otherParents.size()) {
-            if (!myParents.get(i).isSameTag(otherParents.get(i))) {
+            // Use loose comparison for isSameTag call
+            if (!myParents.get(i).isSameTag(otherParents.get(i), true)) {
                 isSame = false;
             } else {
                 // After the while, the index i-1 must be the last common parent

--- a/src/main/java/org/outerj/daisy/diff/html/dom/TagNode.java
+++ b/src/main/java/org/outerj/daisy/diff/html/dom/TagNode.java
@@ -137,12 +137,23 @@ public class TagNode extends Node implements Iterable<Node> {
     }
 
     /**
-     * checks tags for being semantically equivalent if it's from 
-     * a different tree and for being the same object if it's 
-     * from the same tree as <code>this</code> tag.
+     * Uses strict comparison to check tags for being semantically
+     * equivalent if it's from a different tree and for being the
+     * same object if it's from the same tree as <code>this</code> tag.
      * @param other - tag to compare to
      */
     public boolean isSameTag(TagNode other) {
+        return isSameTag(other, false);
+    }
+
+    /**
+     * checks tags for being semantically equivalent if it's from
+     * a different tree and for being the same object if it's
+     * from the same tree as <code>this</code> tag.
+     * @param other - tag to compare to
+     * @param looseComparison - if true, attribute differences are ignored
+     */
+    public boolean isSameTag(TagNode other, boolean looseComparison) {
         if (other == null) {
 			return false;
 		}
@@ -163,10 +174,10 @@ public class TagNode extends Node implements Iterable<Node> {
 			return false;
 		}
 
-        return equals((TagNode) obj);
+        return equals((TagNode) obj, false);
     }
 
-    private boolean equals(TagNode tagNode) {
+    private boolean equals(TagNode tagNode, boolean looseComparison) {
         if (tagNode == this) {
 			return true;
 		}
@@ -179,7 +190,7 @@ public class TagNode extends Node implements Iterable<Node> {
         //still a chance for being equal
         //if we are in the different tree
         //we should use semantic equivalence instead
-        if (isSimilarTag(tagNode)) {
+        if (isSimilarTag(tagNode, looseComparison)) {
 //            if (getParent() != null && tagNode.getParent() != null) {
 //                int indexInParent = getParent().getIndexOf(this);
 //                int otherIndexInParent = tagNode.getParent().getIndexOf(tagNode);
@@ -222,14 +233,15 @@ public class TagNode extends Node implements Iterable<Node> {
      * The tags may be from different trees. If the tag name and attributes
      * are the same, the result will be <code>true</code>.
      * @param another the tag to compare with
+     * @param looseComparison if true, attribute differences are ignored
      * @return wether this tag is similar to the other node
      */
-    protected boolean isSimilarTag(Node another) {
+    protected boolean isSimilarTag(Node another, boolean looseComparison) {
     	boolean result = false;
     	if (another instanceof TagNode) {
     		TagNode otherNode = (TagNode) another;
     		if (this.getQName().equalsIgnoreCase(otherNode.getQName())) {
-    			result = hasSameAttributes(otherNode.getAttributes());
+    			result = looseComparison || hasSameAttributes(otherNode.getAttributes());
     		}
     	}
 		return result;


### PR DESCRIPTION
Fix for issue <Node.getLastCommonParent Algorithm [#5](https://github.com/DaisyDiff/DaisyDiff/issues/5)> following suggestion in the comments on that issue. Although the issue has been closed it is still a problem in the product. 

This change allows the getLastCommonParent algorithm to call the TagNode.isSameTag() method with an extra parameter to force it to ignore attribute differences when comparing tags.